### PR TITLE
Revert "Pingging Google to re-index the sitemap on deploy"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,12 +71,3 @@ jobs:
           exclude: |
             .well-known/pki-validation/*
             cgi-bin/*
-
-  ping-google:
-    name: "Ping Google to re-index the sitemap"
-    runs-on: ubuntu-latest
-    needs: deploy
-    steps:
-      - name: "Ping Google"
-        run: |
-          curl http://www.google.com/ping?sitemap=https://dedic.eu/sitemap.xml


### PR DESCRIPTION
This reverts commit 58642ddb18ddd52c1084594cd98676dda726bc2a.

https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping
